### PR TITLE
Load metrics in a single http get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - PNDA-2827: Changed the display of the application metrics to lose the filter info.
 
+### Fixed
+- PNDA-3086: Load metrics in a single http get to fix performance issue.
+
 ## [0.1.4] 2017-01-02
 ### Changed
 - PNDA-2537: modify version of grunt compress to 1.3.0 in order to work with npm 3.10

--- a/console-frontend/js/services/MetricService.js
+++ b/console-frontend/js/services/MetricService.js
@@ -29,7 +29,7 @@ angular.module('appServices').factory('MetricService', ['$resource', 'ConfigServ
     var dataManager = ConfigService.backend["data-manager"];
     var host = dataManager.host;
     var port = dataManager.port;
-    var MetricService = $resource('http://' + host + ':' + port + '/metrics/:metricId', {}, {
+    var MetricService = $resource('http://' + host + ':' + port + '/metrics/:metricId?values=y', {}, {
       query: { method:'GET', params:{ metricId:'' }, isArray:true, transformResponse: function(data) {
         var json = JSON.parse(data);
 
@@ -38,62 +38,22 @@ angular.module('appServices').factory('MetricService', ['$resource', 'ConfigServ
           // for each metric, get its latest value asynchronously using the /metrics/metricId API
           var metrics = [];
 
-          var deferDummyMetricValue = function() {
+          angular.forEach(json.metrics, function (metric) {
             var deferred = $q.defer();
-            var resObj = {
-              source: "default",
-              value: "UNAVAILABLE",
-              timestamp: 1451606400000 // 1st Jan 2016 - this date doesn't matter, it just needs to be in the past
-            };
-            deferred.resolve(resObj);
-            return deferred.promise;
-          };
+            deferred.resolve(metric.info);
+            var promisedMetric = { name: metric.name, info: $q.all([deferred.promise]) };
+            metrics.push(promisedMetric);
+          });
+
+          var dummyValue = { source: "default", value: "UNAVAILABLE",timestamp: 1451606400000 };
 
           // add dummy metrics to make sure all components appear
           angular.forEach(ConfigService.dummy_metrics, function(m) {
-            metrics.push({
-              name: m,
-              info: $q.all([deferDummyMetricValue()])
-            });
-          });
-
-          json.metrics.map(function(metric) {
-            // defer getting its value using a promise (asynchronously)
-            var getMetricInfo = function(m) {
+            var foundMetric = $filter('getByName')(metrics, m);
+            if (foundMetric.length === 0) {
               var deferred = $q.defer();
-              $http.get('http://' + host + ':' + port + '/metrics/' + m)
-                .then(function successCallback(response) {
-                  // this callback will be called asynchronously
-                  // when the response is available
-
-                  var resObj = {
-                    source: response.data.currentData.source,
-                    value: response.data.currentData.value,
-                    timestamp: parseInt(response.data.currentData.timestamp, Constants.RADIX_DECIMAL)
-                  };
-
-                  if (response.data.metric.indexOf('.health') !== -1) {
-                    resObj.causes = response.data.currentData.causes;
-                  }
-
-                  return deferred.resolve(resObj);
-                }, function errorCallback(response) {
-                  // called asynchronously if an error occurs
-                  // or server returns response with an error status.
-                  deferred.reject('error ' + response);
-                });
-
-              return deferred.promise;
-            };
-
-            // if we already have this metric, replace the value
-            var foundMetric = $filter('getByName')(metrics, metric);
-            if (foundMetric.length > 0) {
-              foundMetric[0].info = $q.all([getMetricInfo(metric)]);
-            } else {
-              // add this metric to the array
-              // at the moment we just have its name but we're using a promise to get its latest value from the API
-              metrics.push({ name: metric, info: $q.all([getMetricInfo(metric)]) });
+              deferred.resolve(dummyValue);
+              metrics.push({ name: m, info: $q.all([deferred.promise]) });
             }
           });
           return metrics;


### PR DESCRIPTION
Instead of executing a get per metric, just fetch them all in one go.
This avoids the performance issue associated when there are lots of
metrics. There is now a problem in theory that the single request could
grow so large that itself causes problems, we should look at
implementing paging in future to fetch the metrics in batches.

PNDA-3086