### PR TITLE
PNDA-3099

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 ### Added:
 - PNDA-3099: Long topic names overlap text box on topic view on console home page
 
-## [Unreleased]
 ### Added:
 - PNDA-2445: Support for Hortonworks HDP
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added:
+- PNDA-3099: Long topic names overlap text box on topic view on console home page
+
+## [Unreleased]
+### Added:
 - PNDA-2445: Support for Hortonworks HDP
 
 ## [0.2.0] 2017-06-29

--- a/console-frontend/less/PNDA.less
+++ b/console-frontend/less/PNDA.less
@@ -296,6 +296,12 @@ pnda-tree-view {
     padding-left: 10px;
 }
 
+.word-wrap-enabled{
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .loader-container {
     height: 30px;
     margin-left: 10px;

--- a/console-frontend/partials/components/pnda-deployment-manager.html
+++ b/console-frontend/partials/components/pnda-deployment-manager.html
@@ -17,7 +17,7 @@
       No application created
     </div>
     <div ng-repeat="app in applications | orderBy:orderProp" ng-class="{'started': app.status === 'STARTED'}" class="row application" id="{{app.name | applicationNameId}}" my-post-repeat-directive>
-      <div class="col-md-9 app-name">
+      <div class="col-md-9 app-name word-wrap-enabled" ng-attr-title="{{app.name}}">
         {{app.name}}
       </div>
       <div class="col-md-3 status-icon">

--- a/console-frontend/partials/components/pnda-kafka.html
+++ b/console-frontend/partials/components/pnda-kafka.html
@@ -21,7 +21,7 @@
         </button>
       </div>
       <div ng-repeat="data in topics | toArray | naturalSort" class="row topic group" id="topic_{{data.$key | metricNameClass}}">
-        <div class="col-md-12">
+        <div class="col-md-12 word-wrap-enabled" ng-attr-title="{{data.$key}}">
           {{data.$key}}
         </div>
         <div class="col-md-6 rate in">


### PR DESCRIPTION
**Problem Statement:**
PNDA 3099: Long topic names overlap text box on topic view on console home page

**Analysis**:
When the topic names in Kafka or application name in deployment manager is too long then the text start overflowing to the textbox which makes UI clumsy.

**Change**:
If a topic name or application name is longer than certain limit then the remaining text will get truncated and ellipsis will be shown there. When user hover on ellipsis then he is able to see the entire name. Issue has been fixed for Kafka and deployment manager both.