### PR TITLE
PNDA-3100 - Console home page topic view isn't very usable when there are a lot of topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added:
+- PNDA-3100: Console home page topic view isn't very usable when there are a lot of topics
+### Added:
 - PNDA-2445: Support for Hortonworks HDP
 
 ## [0.2.0] 2017-06-29

--- a/console-frontend/index.html
+++ b/console-frontend/index.html
@@ -30,6 +30,7 @@
   <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
   <script src="/node_modules/gsap/src/minified/TweenMax.min.js"></script>
   <script src="/node_modules/clipboard/dist/clipboard.min.js"></script>
+  <script src="/node_modules/angular-utils-pagination/dirPagination.js"></script>
 
   <!-- PNDA -->
   <script src="js/constants.js"></script>

--- a/console-frontend/js/app.js
+++ b/console-frontend/js/app.js
@@ -33,7 +33,8 @@ var consoleFrontendApp = angular.module('consoleFrontendApp', [
     'logout',
     'appFilters',
     'appComponents',
-    'ngSanitize'
+    'ngSanitize',
+	'angularUtils.directives.dirPagination'
   ])
   .provider('ConfigService', function () {
     var options = {};

--- a/console-frontend/js/components/pndaKafka.js
+++ b/console-frontend/js/components/pndaKafka.js
@@ -28,7 +28,8 @@
 var hideInternalTopics = true;
 var timestampTimeoutMs = 3 * 60 * 1000;
 
-angular.module('appComponents').directive('pndaKafka', ['$filter', '$window', 'HelpService', 'ConfigService',
+angular.module('appComponents').directive('pndaKafka',
+['$filter', '$window', 'HelpService', 'ConfigService',
   function($filter, $window, HelpService, ConfigService) {
   return {
     restrict: 'E',
@@ -39,7 +40,8 @@ angular.module('appComponents').directive('pndaKafka', ['$filter', '$window', 'H
     },
     templateUrl: 'partials/components/pnda-kafka.html',
     link: function(scope) {
-      // initialise the scope, which will be updated when the callback function gets called by the controller
+      // initialise the scope, which will be updated when the callback
+		// function gets called by the controller
       scope.metricName = '';
       scope.class = 'hidden';
       scope.healthClass = '';
@@ -49,12 +51,18 @@ angular.module('appComponents').directive('pndaKafka', ['$filter', '$window', 'H
       scope.metricObj = {};
       scope.severity = '';
       scope.chosenRate = 'MeanRate';
+      scope.selectedPageCount = "5";
       scope.rates = [
         { value:"FifteenMinuteRate", label:"15 minutes rate" },
         { value:"FiveMinuteRate", label:"5 minutes rate" },
         { value:"OneMinuteRate", label:"1 minute rate" },
         { value:"MeanRate", label:"Mean rate" }
       ];
+      scope.pagesmenu = [
+          { value:"5", label:"5 Per Page" },
+          { value:"10", label:"10 Per Page" },
+          { value:"15", label:"15 Per Page" }
+        ];
 
       setInterval(function() {
         var currentTimestamp = Date.now();
@@ -71,12 +79,9 @@ angular.module('appComponents').directive('pndaKafka', ['$filter', '$window', 'H
 
 
       /*
-      scope.showDetails = function() {
-        if (enableModalView(scope.severity)) {
-          scope.showOverview({metricObj: scope.metricObj});
-        }
-      };
-      */
+		 * scope.showDetails = function() { if (enableModalView(scope.severity)) {
+		 * scope.showOverview({metricObj: scope.metricObj}); } };
+		 */
       scope.showComponentInfo = function() {
         scope.showInfo({ brokers: scope.brokers, metricObj: scope.metricObj });
       };
@@ -101,7 +106,7 @@ angular.module('appComponents').directive('pndaKafka', ['$filter', '$window', 'H
       function interpreteValue(value) {
         return (isNaN(value) ? value.replace(/\"/g, '') : Number(value));
       }
-
+      
       scope.numberOfTopicsShown = function() {
         var nb = 0;
         angular.forEach(scope.topics, function(topic) {
@@ -160,13 +165,14 @@ angular.module('appComponents').directive('pndaKafka', ['$filter', '$window', 'H
               // jscs:disable maximumLineLength
               if (!isOldTopic && (match = metric.name.match(/^kafka\.brokers\.(\d+)\.topics\.(.*)\.((?:BytesInPerSec|BytesOutPerSec|MessagesInPerSec))\.(.*)/i)) !== null) {
                 // example: [
-                //   "kafka.brokers.1.topics.avro.internal.testbot.BytesOutPerSec.Count",
-                //   "1", // broker id
-                //   "avro.internal.testbot", // topic
-                //   "BytesOutPerSec", // in or out metric
-                //   "Count", // sub-metric
-                //   index: 0,
-                //   input: "kafka.brokers.1.topics.avro.internal.testbot.BytesOutPerSec.Count"
+                // "kafka.brokers.1.topics.avro.internal.testbot.BytesOutPerSec.Count",
+                // "1", // broker id
+                // "avro.internal.testbot", // topic
+                // "BytesOutPerSec", // in or out metric
+                // "Count", // sub-metric
+                // index: 0,
+                // input:
+				// "kafka.brokers.1.topics.avro.internal.testbot.BytesOutPerSec.Count"
                 // ]
                 brokerId = match[1];
                 var topic = match[2];
@@ -194,7 +200,7 @@ angular.module('appComponents').directive('pndaKafka', ['$filter', '$window', 'H
                 };
 
                 if (hideInternalTopics && (ConfigService.topics.hidden).indexOf(topic) !== -1) {
-//                  console.log("hiding topic", topic);
+// console.log("hiding topic", topic);
                 } else {
                   var value = metric.info.value === undefined ? "" : interpreteValue(metric.info.value);
                   addTopic(broker.topics, topic, inOutMetric, subMetric, value, brokerId);

--- a/console-frontend/js/filters.js
+++ b/console-frontend/js/filters.js
@@ -237,6 +237,7 @@ metricFilters.filter('getByNameForDisplay', function(getByNameFilter) {
 // transform a metric name into a class that can be referenced in a CSS file
 metricFilters.filter('metricNameClass', function() {
   return function(metricName) {
+	if(metricName !== undefined)
     return metricName.toString().replace(/\./g, '-');
   };
 });
@@ -244,6 +245,7 @@ metricFilters.filter('metricNameClass', function() {
 // transform an application name into an ID that can be referenced in a CSS file
 metricFilters.filter('applicationNameId', function() {
   return function(appName) {
+	if(appName !== undefined)
     return "app_" + appName.toString().replace(/\./g, '-');
   };
 });

--- a/console-frontend/less/PNDA.less
+++ b/console-frontend/less/PNDA.less
@@ -43,6 +43,10 @@ hr {
     margin: 30px 0 0;
 }
 
+.margin-right-10{
+	margin-right:10px !important;
+}
+
 .app-status {
     margin-top: -28px;
     margin-right: -50px;
@@ -295,6 +299,99 @@ pnda-tree-view {
 .close {
     padding-left: 10px;
 }
+
+.search-icon{
+	display:table-cell;
+	top:-20px;
+	float:right;
+	padding-right:20px;
+	color:#dddddd;
+}
+
+.border-enabled{
+	border:1px solid #dddddd;
+}
+
+.scroll-bar{
+	max-height:270px;
+	overflow-y:scroll;
+	overflow-x:hidden;
+}
+
+.pagination > li > a{
+	line-height:0.8 !important;
+	color: gray !important;
+}
+
+.pagination > li > span{
+	color: gray !important;
+}
+
+div#applicationList{
+	max-height:215px !important;
+}
+.pagination > .active > a{
+	border-color:gray !important;
+	background-color:gray !important;
+	color:white !important;
+}
+.pagination{
+	margin-bottom:0 !important;
+}
+
+.page-number-button{
+	position:relative;
+	top:-50px;
+	float:right;
+	padding-right:7px;
+	outline:none;
+	background:white;
+}
+
+.page-number-menu{
+	margin-top:-15px;
+	left:25%;
+	padding:5px;
+}
+
+.position-absolute{
+	position: absolute;
+}
+
+.positive-relative{
+	position: relative;
+}
+.margin-bottom-only{
+	margin:0 0 10px 0;
+}
+
+.enlarged-icon{
+	font-size:21px;
+}
+.wide100{
+	width:100%;
+}
+
+.wide80{
+	width:80%;
+}
+
+.wide50{
+	width:50%;
+}
+
+.wide30{
+	width:30%;
+}
+.wide40{
+	width:40%;
+}
+.word-wrap-enabled{
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 
 .loader-container {
     height: 30px;

--- a/console-frontend/package.json
+++ b/console-frontend/package.json
@@ -26,7 +26,8 @@
     "jquery": "2.2.1",
     "socket.io": "1.4.5",
     "gsap": "1.18.2",
-    "clipboard": "1.5.10"
+    "clipboard": "1.5.10",
+	"angular-utils-pagination":"0.11.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.4",

--- a/console-frontend/partials/components/pnda-kafka.html
+++ b/console-frontend/partials/components/pnda-kafka.html
@@ -14,16 +14,31 @@
       No active topics
     </div>
     <div ng-if="numberOfTopicsShown() > 0">
+    <div class="position-relative">
+    <div class="margin-bottom-only">
+     <input ng-model="finding" class="wide100 border-enabled"/>
+     <span class="glyphicon glyphicon glyphicon-search search-icon"></span>
+     </div>
+	<div class="margin-bottom-only">
+	 <label>Show Topic:</label>
+	<button type="button" class="btn btn-default btn-sm" ng-model="selectedPageCount" data-html="1" bs-options="page.value as page.label for page in pagesmenu" bs-select>
+          Action <span class="caret"></span>
+        </button>
+     </div>
+   	 </div>
       <div class="rateChoice">
         <label>Select rate:&nbsp;</label>
         <button type="button" class="btn btn-default btn-sm" ng-model="chosenRate" data-html="1" bs-options="rate.value as rate.label for rate in rates" bs-select>
           Action <span class="caret"></span>
         </button>
       </div>
-      <div ng-repeat="data in topics | toArray | naturalSort" class="row topic group" id="topic_{{data.$key | metricNameClass}}">
+      <div id="topiclist" class="scroll-bar">
+      
+      <div dir-paginate="data in topics | toArray | naturalSort | filter:{'$key':finding} | itemsPerPage: selectedPageCount" class="row topic group margin-right-10" id="topic_{{data.$key | metricNameClass}}" pagination-id="topics">
         <div class="col-md-12">
           {{data.$key}}
         </div>
+        
         <div class="col-md-6 rate in">
           <span class="glyphicon glyphicon-arrow-right"></span>
           {{data.BytesInPerSec[chosenRate] | sumValues | number:1}} Bytes/s
@@ -33,6 +48,12 @@
           <span class="glyphicon glyphicon-arrow-right"></span>
         </div>
       </div>
+      </div>
+      <dir-pagination-controls pagination-id="topics" max-size="3"
+        direction-links="true"
+        boundary-links="true" >
+        </dir-pagination-controls>
     </div>
   </div>
 </div>
+      


### PR DESCRIPTION
**Problem Statement:**
PNDA 3100: Console home page topic view isn't very usable when there are a lot of topics

**Analysis:**
When there is increase in kafka topics, then User have to scroll the main page a lot to see the kafka topic which result "zookeeper" to go down a lot, If he needs to find any specific kafka topic then he has to scroll the main page and go through each topic manually.

**Change:**
We have put a search box, so if user wants to see any specific kafka topic then he can directly search it. We have also put a scroll bar which is specifically for kafka topic, so user can scroll the topics without having to scroll main screen.
Apart from that, we have put pagination too , so that kafka topic block do not get increased beyond a certain point. User can change the number of topic per page, we have provided the dropdown for the same.