### PR TITLE
PNDA-3039 - Console application name text entry is too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ All notable changes to this project will be documented in this file.
 ## [0.2.1] 2017-11-24
 ### Fixed:
 - ISSUE-45: Added UI for opentsdb component with info, help, settings icons and color code for health status in console homepage.
->>>>>>> upstream/develop
 ### Added:
 - PNDA-2445: Support for Hortonworks HDP
 - PNDA-439: When creating an application the user to run the application as is now a required field in the form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added:
+- PNDA-3039: Console application name text entry is too small
+### Added:
 - PNDA-2445: Support for Hortonworks HDP
 
 ## [0.2.0] 2017-06-29

--- a/console-frontend/index.html
+++ b/console-frontend/index.html
@@ -30,6 +30,7 @@
   <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
   <script src="/node_modules/gsap/src/minified/TweenMax.min.js"></script>
   <script src="/node_modules/clipboard/dist/clipboard.min.js"></script>
+  <script src="/node_modules/angular-utils-pagination/dirPagination.js"></script>
 
   <!-- PNDA -->
   <script src="js/constants.js"></script>

--- a/console-frontend/js/app.js
+++ b/console-frontend/js/app.js
@@ -33,7 +33,8 @@ var consoleFrontendApp = angular.module('consoleFrontendApp', [
     'logout',
     'appFilters',
     'appComponents',
-    'ngSanitize'
+    'ngSanitize',
+	'angularUtils.directives.dirPagination'
   ])
   .provider('ConfigService', function () {
     var options = {};

--- a/console-frontend/js/components/pndaDeploymentManager.js
+++ b/console-frontend/js/components/pndaDeploymentManager.js
@@ -44,6 +44,12 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
         scope.fullMetrics = {};
         scope.orderProp = "name";
         scope.severity = '';
+        scope.pagecountApp = "5";
+        scope.pages = [
+            { value:"5", label:"5 Per Page" },
+            { value:"10", label:"10 Per Page" },
+            { value:"15", label:"15 Per Page" }
+          ];
         scope.showDetails = function() {
           if (scope.severity) {
             scope.showOverview({ metricObj: scope.metricObj, metrics: scope.fullMetrics });
@@ -57,7 +63,7 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
         scope.clickCog = function() {
           scope.showConfig({ metricObj: scope.metricObj });
         };
-
+        
         scope.applications = [];
         scope.getAppsList = function() {
           DeploymentManagerService.getApplications().then(function(data) {

--- a/console-frontend/js/filters.js
+++ b/console-frontend/js/filters.js
@@ -237,6 +237,7 @@ metricFilters.filter('getByNameForDisplay', function(getByNameFilter) {
 // transform a metric name into a class that can be referenced in a CSS file
 metricFilters.filter('metricNameClass', function() {
   return function(metricName) {
+	if(metricName !== undefined)
     return metricName.toString().replace(/\./g, '-');
   };
 });
@@ -244,6 +245,7 @@ metricFilters.filter('metricNameClass', function() {
 // transform an application name into an ID that can be referenced in a CSS file
 metricFilters.filter('applicationNameId', function() {
   return function(appName) {
+	if(appName !== undefined)
     return "app_" + appName.toString().replace(/\./g, '-');
   };
 });

--- a/console-frontend/less/PNDA.less
+++ b/console-frontend/less/PNDA.less
@@ -43,6 +43,10 @@ hr {
     margin: 30px 0 0;
 }
 
+.margin-right-10{
+	margin-right:10px !important;
+}
+
 .app-status {
     margin-top: -28px;
     margin-right: -50px;
@@ -295,6 +299,99 @@ pnda-tree-view {
 .close {
     padding-left: 10px;
 }
+
+.search-icon{
+	display:table-cell;
+	top:-20px;
+	float:right;
+	padding-right:20px;
+	color:#dddddd;
+}
+
+.border-enabled{
+	border:1px solid #dddddd;
+}
+
+.scroll-bar{
+	max-height:270px;
+	overflow-y:scroll;
+	overflow-x:hidden;
+}
+
+.pagination > li > a{
+	line-height:0.8 !important;
+	color: gray !important;
+}
+
+.pagination > li > span{
+	color: gray !important;
+}
+
+div#applicationList{
+	max-height:215px !important;
+}
+.pagination > .active > a{
+	border-color:gray !important;
+	background-color:gray !important;
+	color:white !important;
+}
+.pagination{
+	margin-bottom:0 !important;
+}
+
+.page-number-button{
+	position:relative;
+	top:-50px;
+	float:right;
+	padding-right:7px;
+	outline:none;
+	background:white;
+}
+
+.page-number-menu{
+	margin-top:-15px;
+	left:25%;
+	padding:5px;
+}
+
+.position-absolute{
+	position: absolute;
+}
+
+.positive-relative{
+	position: relative;
+}
+.margin-bottom-only{
+	margin:0 0 10px 0;
+}
+
+.enlarged-icon{
+	font-size:21px;
+}
+.wide100{
+	width:100%;
+}
+
+.wide80{
+	width:80%;
+}
+
+.wide50{
+	width:50%;
+}
+
+.wide30{
+	width:30%;
+}
+.wide40{
+	width:40%;
+}
+.word-wrap-enabled{
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 
 .loader-container {
     height: 30px;

--- a/console-frontend/package.json
+++ b/console-frontend/package.json
@@ -26,7 +26,8 @@
     "jquery": "2.2.1",
     "socket.io": "1.4.5",
     "gsap": "1.18.2",
-    "clipboard": "1.5.10"
+    "clipboard": "1.5.10",
+	"angular-utils-pagination":"0.11.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.4",

--- a/console-frontend/partials/components/pnda-deployment-manager.html
+++ b/console-frontend/partials/components/pnda-deployment-manager.html
@@ -13,10 +13,24 @@
 
   <div class="content">
 
-    <div ng-if="applications.length === 0">
+    <div ng-show="applications.length === 0">
       No application created
     </div>
-    <div ng-repeat="app in applications | orderBy:orderProp" ng-class="{'started': app.status === 'STARTED'}" class="row application" id="{{app.name | applicationNameId}}" my-post-repeat-directive>
+    
+    <div class="dropdown" ng-show="applications.length > 0" >
+    <div class="margin-bottom-only">
+      	<input ng-model="searchApp" class="wide100 border-enabled"/>
+      	<span class="glyphicon glyphicon glyphicon-search search-icon"></span>
+     </div>
+     <div class="margin-bottom-only">
+	 <label>Show Apps:</label>
+	<button type="button" class="btn btn-default btn-sm" ng-model="pagecountApp" data-html="1" bs-options="page.value as page.label for page in pages" bs-select>
+          Action <span class="caret"></span>
+        </button>
+     </div>
+    </div>
+    <div id="applicationList" class="scroll-bar" ng-show="applications.length > 0">
+    <div dir-paginate="app in applications | orderBy:orderProp | filter:searchApp | itemsPerPage: pagecountApp" ng-class="{'started': app.status === 'STARTED'}" class="row application margin-right-10" id="{{app.name | applicationNameId}}" my-post-repeat-directive>
       <div class="col-md-9 app-name">
         {{app.name}}
       </div>
@@ -45,6 +59,12 @@
         </div>
       </div>
     </div>
+    </div>
+      <dir-pagination-controls
+         max-size="3"
+        direction-links="true"
+        boundary-links="true" >
+	</dir-pagination-controls>
+    </div>
 
   </div>
-</div>


### PR DESCRIPTION
**Problem Statement:**
PNDA 3039: Console application name text entry is too small.

**Analysis:**
Application names which appear under "deployment-manager" are not properly organised. User have to scroll the main page again and again to access all the application name. Also there is no search facility was available for console application.

**Change:**
We have put a search box, so if user wants to see any specific application then he can directly search it. We have also put a scroll bar which is specifically for applications, so user can scroll the applications without having to scroll main screen.
Apart from that, we have put pagination too , so that deployment-manager block do not get increased beyond a certain point. User can change the number of application per page, we have provided the dropdown for the same.