### PR TITLE
Issue-45:Opentsdb component healthmetric information is not being displayed in console homepage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed:
+- ISSUE-45: Added UI for opentsdb component with info, help, settings icons and color code for health status in console homepage.
 ### Added:
 - PNDA-2445: Support for Hortonworks HDP
 

--- a/console-frontend/conf/dummy-metrics.json
+++ b/console-frontend/conf/dummy-metrics.json
@@ -11,6 +11,7 @@
     {"name": "hadoop.YARN.health", "hadoop_distro": "CDH,HDP"},
     {"name": "hadoop.ZOOKEEPER.health", "hadoop_distro": "CDH,HDP"},
     {"name": "kafka.health", "hadoop_distro": "CDH,HDP"},
-    {"name": "zookeeper.health", "hadoop_distro": "CDH,HDP"}
+    {"name": "zookeeper.health", "hadoop_distro": "CDH,HDP"},
+    {"name": "opentsdb.health", "hadoop_distro": "CDH,HDP"}
 ]
 }

--- a/console-frontend/help/topics.json
+++ b/console-frontend/help/topics.json
@@ -69,6 +69,11 @@
         "Impala is only available with the Cloudera distribution of Hadoop"],
       "link": "http://impala.io"
     },
+     "opentsdb.health": {
+      "body": ["OpenTSDB is a scalable time series database that lets you store and serve massive amounts of time series data,without losing granularity.",
+        "In PNDA, a custom application (reading data from Kafka or HDFS for example) could write time series and store them in OpenTSDB."],
+      "link": "http://opentsdb.net/"
+    },
     "hadoop.HQUERY.health": {
       "body": ["Apache Hive is a parallel execution engine for SQL queries. It supports low-latency access and interactive exploration of data in HDFS and HBase.",
         "Hive allows data to be stored in a raw form in HDFS and HBase, with aggregation performed at query time without requiring upfront aggregation of data."],

--- a/console-frontend/help/topics.json
+++ b/console-frontend/help/topics.json
@@ -70,7 +70,7 @@
       "link": "http://impala.io"
     },
      "opentsdb.health": {
-      "body": ["OpenTSDB is a scalable time series database that lets you store and serve massive amounts of time series data,without losing granularity.",
+      "body": ["OpenTSDB is a scalable time series database that lets you store and serve massive amounts of time series data, without losing granularity.",
         "In PNDA, a custom application (reading data from Kafka or HDFS for example) could write time series and store them in OpenTSDB."],
       "link": "http://opentsdb.net/"
     },

--- a/console-frontend/js/controllers/MetricsListCtrl.js
+++ b/console-frontend/js/controllers/MetricsListCtrl.js
@@ -312,7 +312,7 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
         } else if (source === "deployment-manager") {
           resolutionUrl = ConfigService.userInterfaceIndex["PNDA logserver"];
         } else if (source === "opentsdb") {
-          resolutionUrl =ConfigService.userInterfaceIndex[opentsdbIndex].split(",")[0];
+          resolutionUrl = ConfigService.userInterfaceIndex[opentsdbIndex].split(",")[0];
         }else if(source === "grafana"){
         //for grafana, the string is a comma-separated list
         resolutionUrl = $scope.dm_endpoints[source].split(',')[0];

--- a/console-frontend/js/controllers/MetricsListCtrl.js
+++ b/console-frontend/js/controllers/MetricsListCtrl.js
@@ -305,15 +305,19 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
 
     function findResolutionUrlForSource(source, showDefault) {
       var resolutionUrl = "/";
+      var opentsdbIndex = "OpenTSDB";
       if ($scope.dm_endpoints !== undefined) {
         if (source === "kafka") {
           resolutionUrl = $scope.dm_endpoints.kafka_manager;
         } else if (source === "deployment-manager") {
           resolutionUrl = ConfigService.userInterfaceIndex["PNDA logserver"];
-        } else if (source === "opentsdb" || source === "grafana") {
-          // for opentsdb and grafana, the string is a comma-separated list
-          resolutionUrl = $scope.dm_endpoints[source].split(',')[0];
-        } else if ((source === "hdfs01" || source === "HDFS") && showDefault !== true) {
+        } else if (source === "opentsdb") {
+          resolutionUrl =ConfigService.userInterfaceIndex[opentsdbIndex].split(",")[0];
+        }else if(source === "grafana"){
+        //for grafana, the string is a comma-separated list
+        resolutionUrl = $scope.dm_endpoints[source].split(',')[0];
+        } 
+        else if ((source === "hdfs01" || source === "HDFS") && showDefault !== true) {
           if (ConfigService.hadoop_distro === 'CDH') {
             resolutionUrl = ConfigService.userInterfaceIndex.Hue + "/filebrowser/";
           } else {

--- a/console-frontend/js/filters.js
+++ b/console-frontend/js/filters.js
@@ -214,7 +214,6 @@ metricFilters.filter('getByName', function() {
         matches.push(input[i]);
       }
     }
-
     return matches;
   };
 });
@@ -264,6 +263,9 @@ metricFilters.filter('metricNameForDisplay', function() {
       case "hadoop.IMPALA.health":
         display = "Impala";
         break;
+      case "opentsdb.health":
+          display = "OpenTSDB";
+          break;
       case "hadoop.HBASE.health":
         display = "HBase";
         break;

--- a/console-frontend/partials/curated-view.html
+++ b/console-frontend/partials/curated-view.html
@@ -112,17 +112,10 @@
                     </div>
                   </div>
                 </div>
-                <div class="col-md-12 group" id="metrics-UIs" ng-if="findComponentUrl('OpenTSDB') !== '' && findComponentUrl('Grafana') !== ''">
+                <div class="col-md-12 group" id="metrics-UIs" ng-if="findComponentUrl('Grafana') !== ''">
                   <div class="title">Metrics</div>
                   <div class="content">
-                    <div pnda-basic-component class="fake-component" ng-if="findComponentUrl('OpenTSDB') !== ''">
-                      <a target="_blank" href="{{findFirstComponentUrl('OpenTSDB')}}">
-                        <div class="ui-link">OpenTSDB</div>
-                        <div class="overlay">
-                          <span class="glyphicon glyphicon-new-window"></span>
-                        </div>
-                      </a>
-                    </div>
+                  <pnda-basic-component on-get-metric-data="getMetricData('opentsdb',cbFn,healthStatusCbFn,true)" show-overview="showModal(metricObj, metrics)" show-config="showConfigPage(metricObj)" ></pnda-basic-component>
                     <div pnda-basic-component class="fake-component" ng-if="findComponentUrl('Grafana') !== ''">
                       <a target="_blank" href="{{findComponentUrl('Grafana')}}">
                         <div class="ui-link">Grafana</div>


### PR DESCRIPTION
**Problem Statement:**
ISSUE 45: Opentsdb component healthmetric information is not being displayed in console homepage.

**Analysis:**
There are no proper UI representation of information related to OpenTSDB. Presently, OpenTsdb has one URL on console homepage which redirects to another page. User cannot see the health status of opentsdb. 

**Change:**
Added UI represntation of opentsdb. It is a block like structure on homepage which has a color code which depends on health status of openTsdb. That block has three icon which are info, help and settings respectively.