### PR TITLE
PNDA-2282: Pass more specific reason back in case of bad health for deployment manager

### DIFF
--- a/console-frontend/js/controllers/MetricsListCtrl.js
+++ b/console-frontend/js/controllers/MetricsListCtrl.js
@@ -311,6 +311,9 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
           resolutionUrl = $scope.dm_endpoints.kafka_manager;
         } else if (source === "deployment-manager") {
           resolutionUrl = ConfigService.userInterfaceIndex["PNDA logserver"];
+          // setting the search/query string to "deployment manager"
+          resolutionUrl += "/#/dashboard/Default?_g=()&_a=(filters:!()," +
+          "query:(query_string:(analyze_wildcard:!t,query:%27deployment-manager%27)),title:Default)";
         } else if (source === "opentsdb") {
           resolutionUrl = ConfigService.userInterfaceIndex[opentsdbIndex].split(",")[0];
         }else if(source === "grafana"){


### PR DESCRIPTION
# Problem Statement:

PNDA-2282: Pass more specific reason back in case of bad health for deployment manager

# Analysis:

The exception handling for deployment manager APIs not reachable is done at very broad level.
It simply says - api's not working if api call doesn't give response.

# Change:

Updated the link redirecting to the kafka point, so that it filters out the errors records specific to the deployment manager as source instead of showing all the error records.

# Test details:

Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification pending for OpenStack