### PR TITLE
Issue #59 Fix: Change 'More Info' link position

### DIFF
--- a/console-frontend/partials/applications.html
+++ b/console-frontend/partials/applications.html
@@ -89,10 +89,11 @@
                         </tr>
                         <tr>
                           <th>Status</th>
-                          <td>{{ fullApplicationDetail.status | changeAppStatusForDisplay }}</td>
+                          <td>{{ fullApplicationDetail.status | changeAppStatusForDisplay }}
+                           <span> <button type="button" class="btn btn-link" ng-click="showInfoModal()">More info</button></span>
+                          </td>
                         </tr>
                       </table>
-					  <button type="button" class="btn btn-link" ng-click="showInfoModal()" style="margin-left: -10px;">More info</button>
                     </div>
                     <div id="tab-deployment-properties" class="tab-pane fade" ng-if="viewAppProps">
                       <pnda-tree-view json="{{ appDetailJson }}" editable="false" on-confirm-overrides="getOverrides(overrides)"></pnda-tree-view>


### PR DESCRIPTION
# Problem Statement:
- Issue #59: Change the location of "More Info" link on applications page.

# Change:
- Move the position of “More Info” link, adjacent to application status on applications page.