### PR TITLE
PNDA-4226: Improve Session handling

### DIFF
--- a/console-frontend/index.html
+++ b/console-frontend/index.html
@@ -22,6 +22,8 @@
   <script src="/node_modules/angular-strap/dist/angular-strap.js"></script>
   <script src="/node_modules/angular-strap/dist/angular-strap.tpl.min.js"></script>
   <script src="/node_modules/angular-cookies/angular-cookies.js"></script>
+  <script src="/node_modules/ng-idle/angular-idle.min.js"></script>
+  <script src="/node_modules/angular-utils-pagination/dirPagination.js"></script>
 
   <!-- Other libraries -->
   <script src="/node_modules/d3/d3.min.js"></script>
@@ -30,7 +32,6 @@
   <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
   <script src="/node_modules/gsap/src/minified/TweenMax.min.js"></script>
   <script src="/node_modules/clipboard/dist/clipboard.min.js"></script>
-  <script src="/node_modules/angular-utils-pagination/dirPagination.js"></script>
 
   <!-- PNDA -->
   <script src="js/constants.js"></script>

--- a/console-frontend/js/app.js
+++ b/console-frontend/js/app.js
@@ -34,7 +34,8 @@ var consoleFrontendApp = angular.module('consoleFrontendApp', [
     'appFilters',
     'appComponents',
     'ngSanitize',
-	'angularUtils.directives.dirPagination'
+    'angularUtils.directives.dirPagination',
+    'ngIdle'
   ])
   .provider('ConfigService', function () {
     var options = {};

--- a/console-frontend/package.json
+++ b/console-frontend/package.json
@@ -27,7 +27,8 @@
     "socket.io": "1.4.5",
     "gsap": "1.18.2",
     "clipboard": "1.5.10",
-	"angular-utils-pagination":"0.11.0"
+    "angular-utils-pagination":"0.11.0",
+    "ng-idle": "1.3.2"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.4",

--- a/console-frontend/partials/modals/session-expiry-warning.html
+++ b/console-frontend/partials/modals/session-expiry-warning.html
@@ -1,0 +1,16 @@
+<div class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header" ng-show="title">
+        <button type="button" class="close" ng-click="$hide()">&times;</button>
+        <h4>{{title}}</h4>
+      </div>
+      <div class="modal-body">
+        <p>Your session will expire in {{timeoutWarningInSec}} seconds. Press any key or click anywhere to remain logged in.</p>
+      </div>
+      <div class="modal-footer">
+        <button id="sessionModalHideBtn" type="button" class="btn btn-default" ng-click="$hide()">OK</button>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# Problem Statement:
- PNDA 4226: Session expiration on no activity for x (max age) time.

# Analysis:
- Currently session timeout or max age is set for one day.
- Session expires after one day irrespective of user is active or not.
- No warning message display before session timeout.

# Change:
- Add a new library **ng-idle** (version 1.3.2) for session handling.
- Get session max age and warning message duration from backend.
- Set default value for session max age as 6 hours and warning message duration as 30 seconds.
- A Warning message display before session timeout.
- Session will timeout in case of inactivity for session max age time and login page display.