### PR TITLE
PNDA-4234:Fix Hive query cog link

### DIFF
--- a/console-frontend/js/controllers/MetricsListCtrl.js
+++ b/console-frontend/js/controllers/MetricsListCtrl.js
@@ -335,6 +335,9 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
             '#/main/views/WORKFLOW_MANAGER/1.0.0/PNDA_WORKFLOW';
         } else if (source === "flink") {
             resolutionUrl = ConfigService.userInterfaceIndex[flinkIndex];
+        } else if (source === "HQUERY") {
+          resolutionUrl = ConfigService.userInterfaceIndex["Hadoop Cluster Manager"] +
+          "#/main/view/HIVE/auto_hive_instance";
         } else if (source === "AMBARI" || source === "CM") {
           resolutionUrl = ConfigService.userInterfaceIndex["Hadoop Cluster Manager"];
         } else if ($scope.dm_endpoints.cm_status_links !== undefined) {


### PR DESCRIPTION
# Problem Statement:
- PNDA-4234 : Hive query cog sends you to about:blank

# Change:
- Add the cog URL for HIVE query which is http://ambarihost:8080/#/main/view/HIVE/auto_hive_instance