### PR TITLE
PNDA-4047: Display integrity error for dataset

### DIFF
--- a/console-frontend/less/PNDA.less
+++ b/console-frontend/less/PNDA.less
@@ -621,3 +621,7 @@ div#applicationOverviewModal{
 	  background-image: -ms-linear-gradient(top, #000000, #000000);
 	  background-image: -o-linear-gradient(top, #000000, #000000);
 }
+
+.glyphicon-warning-sign{
+   color: orange;
+}

--- a/console-frontend/partials/datasets.html
+++ b/console-frontend/partials/datasets.html
@@ -23,14 +23,19 @@
             </thead>
             <tbody>
               <tr ng-repeat="dataset in datasets | filter:filterDatasets | orderBy:orderProp">
-                <td>{{dataset.id}}</td>
+                <td>{{dataset.id}}
+                <span class="glyphicon glyphicon-warning-sign pad-left-10 tooltip-test"
+                      data-title="No dataset on HDFS for associated policy" 
+                      ng-show="dataset.policy === 'integrity_error'" bs-tooltip>
+                </span>
+                </td>
                 <td class="padding-select">
-                  <select ng-model="dataset.mode" ng-change="datasetChanged()">
+                  <select ng-model="dataset.mode" ng-change="datasetChanged()" ng-show="dataset.policy !== 'integrity_error'">
                     <option ng-repeat="m in modes">{{m}}</option>
                   </select>
                 </td>
                 <td class="padding-select">
-                  <div ng-show="dataset.mode !== 'keep'">
+                  <div ng-show="dataset.mode !== 'keep' && dataset.policy !== 'integrity_error'">
                     <select ng-model="dataset.policy" ng-change="datasetChanged()">
                       <option ng-repeat="p in policies">{{p}}</option>
                     </select>


### PR DESCRIPTION
# Problem Statement:
PNDA-4047 : Console failing to show data management integrity error

# Change:
- Add a warning triangle icon next to the entry with the integrity error.
- Add a tooltip on the warning triangle with the  message "“No dataset on HDFS for associated policy”.
- Hide policy and mode dropdown in case of integrity_error.