### PR TITLE
PNDA-4222: Display cog links for all opentsdb nodes

### DIFF
--- a/console-frontend/js/controllers/MetricsListCtrl.js
+++ b/console-frontend/js/controllers/MetricsListCtrl.js
@@ -82,8 +82,18 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
     };
 
     $scope.showConfigPage = function(healthInfo) {
-      var link = findResolutionUrlForSource(healthInfo.info.source);
-      $window.open(link, '_blank');
+     var opentsdbIndex = "OpenTSDB";
+     if(healthInfo.info.source === "opentsdb" &&
+        ConfigService.userInterfaceIndex[opentsdbIndex].indexOf(",") !== -1){
+           var fields = {
+           title: "OpenTSDB",
+           links : ConfigService.userInterfaceIndex[opentsdbIndex].split(",")
+           };
+           ModalService.createModalView('partials/modals/opentsdb.html', fields);
+     }else{
+           var link = findResolutionUrlForSource(healthInfo.info.source);
+           $window.open(link, '_blank');
+     }
     };
 
     function resetTrafficLightStatus() {
@@ -317,7 +327,7 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
           resolutionUrl += "/#/dashboard/Default?_g=()&_a=(filters:!()," +
           "query:(query_string:(analyze_wildcard:!t,query:%27deployment-manager%27)),title:Default)";
         } else if (source === "opentsdb") {
-          resolutionUrl = ConfigService.userInterfaceIndex[opentsdbIndex].split(",")[0];
+          resolutionUrl = ConfigService.userInterfaceIndex[opentsdbIndex];
         } else if (source === "grafana") {
         //for grafana, the string is a comma-separated list
           resolutionUrl = $scope.dm_endpoints[source].split(',')[0];

--- a/console-frontend/less/PNDA.less
+++ b/console-frontend/less/PNDA.less
@@ -625,3 +625,10 @@ div#applicationOverviewModal{
 .glyphicon-warning-sign{
    color: orange;
 }
+table.custom-table{
+   margin-top: 20px;
+   border: 1px solid #e5e5e5;
+}
+table.custom-table > thead{
+   background-color: #e5e5e5;
+}

--- a/console-frontend/partials/modals/opentsdb.html
+++ b/console-frontend/partials/modals/opentsdb.html
@@ -1,0 +1,29 @@
+<div class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header" ng-show="title">
+        <button type="button" class="close" ng-click="$hide()">&times;</button>
+        <h4>{{title}}</h4>
+      </div>
+      <div class="modal-body">
+        <table class="table table-hover table-condensed custom-table">
+          <thead>
+          <tr>
+            <th>Node Name</th>
+            <th>Link</th>
+          </tr>
+          </thead>
+          <tr ng-repeat="link in links track by $index">
+            <td class="text">TSDB {{$index}}</td>
+            <td class="text"><a href="{{link}}" target="_blank">
+            <span class="glyphicon glyphicon-new-window"></span></a>
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" ng-click="$hide()">Close</button>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# Problem Statement: 
- PNDA-4222: PNDA dashboard's OpenTSDB element does not have option to access multiple OpenTSDB node's UI

# Change:
- Display a modal with all tsdb node names and their respective links in case of multiple tsdb node. 