### PR TITLE
PNDA-4265: Route socket.io through front end HTTP server and reverse …

### DIFF
--- a/console-frontend/index.html
+++ b/console-frontend/index.html
@@ -25,13 +25,12 @@
 
   <!-- Other libraries -->
   <script src="/node_modules/d3/d3.min.js"></script>
-  <script src="/node_modules/socket.io-client/socket.io.js"></script>
   <script src="/node_modules/jquery/dist/jquery.min.js"></script>
   <script src="/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
   <script src="/node_modules/gsap/src/minified/TweenMax.min.js"></script>
   <script src="/node_modules/clipboard/dist/clipboard.min.js"></script>
   <script src="/node_modules/angular-utils-pagination/dirPagination.js"></script>
-
+  <script src="/node_modules/socket.io-client/socket.io.js"></script>
   <!-- PNDA -->
   <script src="js/constants.js"></script>
   <script src="js/modules.js"></script>

--- a/console-frontend/js/services/socket.js
+++ b/console-frontend/js/services/socket.js
@@ -13,9 +13,7 @@ angular.module('appServices').factory('socket', ['$rootScope', 'ConfigService',
   function ($rootScope, ConfigService) {
     var dataManager = ConfigService.backend["data-manager"];
     var host = dataManager.host;
-    var port = dataManager.port;
-
-    var socket = io.connect('http://' + host + ':' + port);
+    var socket = io.connect();
     return {
       on: function (eventName, callback) {
         socket.on(eventName, function () {

--- a/console-frontend/package.json
+++ b/console-frontend/package.json
@@ -27,7 +27,7 @@
     "socket.io": "1.4.5",
     "gsap": "1.18.2",
     "clipboard": "1.5.10",
-	"angular-utils-pagination":"0.11.0"
+	  "angular-utils-pagination":"0.11.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.4",


### PR DESCRIPTION
## Problem statement
Current implementation requires an additional port through to the socket.io server. Thus drill a hole in the firewall to the edge node. This also causes CORS complications. 

## Update
- Update to make client request socket.io client dependency via reverse proxy
- Update socket service to use reverse proxy URL
- Remove socket.io dependency from package file. 

## Tests
- CentOS/Pico
- Test links to different backend services. 
