### PR TITLE
PNDA-4133: Clock drift issue resolve

### DIFF
--- a/console-frontend/index.html
+++ b/console-frontend/index.html
@@ -44,6 +44,7 @@
   <script src="js/services/DeploymentManagerService.js"></script>
   <script src="js/services/DatasetService.js"></script>
   <script src="js/services/socket.js"></script>
+  <script src="js/services/timer.js"></script>
   <script src="js/services/ModalService.js"></script>
   <script src="js/services/HelpService.js"></script>
   <script src="js/services/UtilService.js"></script>

--- a/console-frontend/js/components.js
+++ b/console-frontend/js/components.js
@@ -34,17 +34,12 @@ var timestampTimeoutMs = 3 * 60 * 1000; // 3 minutes
 // - WARN
 // - WARN_NO_RECENT_UPDATE
 // - ERROR
-function healthStatus(lastKnownHealthStatus, lastUpdateTimestamp, now) {
+function healthStatus(lastKnownHealthStatus, lastUpdateTimestamp, diff) {
   // if it's already a warning or an error, leave it as it is
   if (lastKnownHealthStatus !== "OK") {
     return lastKnownHealthStatus;
   }
-
-  // otherwise figure out if it's overdue
-  var currentTimestamp = (now !== undefined ? now : Date.now());
-
-  return (currentTimestamp - lastUpdateTimestamp > timestampTimeoutMs
-    ? "WARN_NO_RECENT_UPDATE" : lastKnownHealthStatus);
+  return (diff > timestampTimeoutMs ? "WARN_NO_RECENT_UPDATE" : lastKnownHealthStatus);
 }
 
 function enableModalView(severity) {

--- a/console-frontend/js/components/pndaDeploymentManager.js
+++ b/console-frontend/js/components/pndaDeploymentManager.js
@@ -26,8 +26,8 @@
 *-------------------------------------------------------------------------------*/
 
 angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', 'DeploymentManagerService',
-  '$timeout', 'socket', 'ModalService', 'HelpService','$cookies',
-  function($filter, DeploymentManagerService, $timeout, socket, ModalService, HelpService, $cookies) {
+  '$timeout', 'socket', 'ModalService', 'HelpService','$cookies','customTimer',
+  function($filter, DeploymentManagerService, $timeout, socket, ModalService, HelpService, $cookies, customTimer) {
     return {
       restrict: 'E',
       scope: {
@@ -45,6 +45,8 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
         scope.orderProp = "name";
         scope.severity = '';
         scope.userName = $cookies.get('user');
+        scope.timeDiff = 0;
+        var defaultTimeInterval = 1000;
         scope.showDetails = function() {
           if (scope.severity) {
             scope.showOverview({ metricObj: scope.metricObj, metrics: scope.fullMetrics });
@@ -195,7 +197,6 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
         });
 
         // the callback function expects an array of matching metrics
-        var oldestTimestamp;
         var callbackFn = function(metricData) {
           if (metricData.length > 0) {
             // for deployment manager we're looking for:
@@ -205,12 +206,10 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
             // deployment-manager.packages_deployed_count
             // deployment-manager.packages_deployed_succeeded
             // deployment-manager.packages_deployed_time_ms
-            oldestTimestamp = Date.now() + 60000; // one minute in the future
             angular.forEach(metricData, function(metric) {
               scope.fullMetrics[metric.name] = metric;
 
               scope.metrics[metric.name.substring(metric.name.lastIndexOf(".") + 1)] = metric.info.value;
-              oldestTimestamp = Math.min(oldestTimestamp, metric.info.timestamp);
             });
 
             var healthMetric = metricData.find(function(element) {
@@ -222,9 +221,10 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
             if (healthMetric !== undefined) {
               scope.class = '';
               scope.timestamp = healthMetric.info.timestamp;
+              scope.timeDiff = 0;
               scope.severity = healthMetric.info.value;
               scope.metricObj = healthMetric;
-              scope.healthClass = "health_" + healthStatus(healthMetric.info.value, scope.timestamp);
+              scope.healthClass = "health_" + healthStatus(healthMetric.info.value, scope.timestamp, scope.timeDiff);
               scope.healthClass += (enableModalView(scope.severity) ? " clickable" : " ");
               scope.latestHealthStatus = healthMetric.info.value;
               scope.isUnavailable = (healthMetric.info.value === "UNAVAILABLE");
@@ -233,9 +233,19 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
             }
           }
         };
+        
+        scope.callback = function() {
+            scope.timeDiff += defaultTimeInterval;
+        };
+        
+        var timerCallbackId = customTimer.on(scope.callback);
+         
+         scope.$on('$destroy',function(){
+            customTimer.off(timerCallbackId);
+         });
 
         var healthStatusCallbackFn = function(now) {
-          scope.healthClass = " health_" + healthStatus(scope.latestHealthStatus, scope.timestamp, now);
+          scope.healthClass = " health_" + healthStatus(scope.latestHealthStatus, scope.timestamp, scope.timeDiff);
         };
 
         scope.onGetMetricData({ cbFn: callbackFn, healthStatusCbFn: healthStatusCallbackFn });

--- a/console-frontend/js/components/pndaYarn.js
+++ b/console-frontend/js/components/pndaYarn.js
@@ -24,7 +24,8 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 *-------------------------------------------------------------------------------*/
 
-angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService', function($filter, HelpService) {
+angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService','customTimer',
+        function($filter, HelpService, customTimer) {
   return {
     restrict: 'E',
     scope: {
@@ -42,6 +43,8 @@ angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService',
       scope.metricObj = {};
       scope.fullMetrics = {};
       scope.severity = '';
+      scope.timeDiff = 0;
+      var defaultTimeInterval = 1000;
 
       // total = allocated + available
       scope.memory = { total: 0, available: 0, allocated: 0, allocatedPercentage: 0, allocatedPercentageStyle: '' };
@@ -78,7 +81,8 @@ angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService',
               scope.severity = metric.info.value;
               scope.metricObj = metric;
               scope.timestamp = metric.info.timestamp;
-              var status = healthStatus(metric.info.value, scope.timestamp);
+              scope.timeDiff = 0;
+              var status = healthStatus(metric.info.value, scope.timestamp, scope.timeDiff);
               scope.healthClass = "health_" + status;
               scope.isUnavailable = (metric.info.value === "UNAVAILABLE");
 
@@ -111,9 +115,18 @@ angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService',
           showMetricUpdateAnimation($("pnda-yarn .health"));
         }
       };
+      
+      scope.callback = function() {
+          scope.timeDiff += defaultTimeInterval;
+      };
+      var timerCallbackId = customTimer.on(scope.callback);
+      
+      scope.$on('$destroy',function(){
+          customTimer.off(timerCallbackId);
+      });
 
-      var healthStatusCallbackFn = function(now) {
-        var status = healthStatus(scope.latestHealthStatus, scope.timestamp, now);
+      var healthStatusCallbackFn = function() {
+        var status = healthStatus(scope.latestHealthStatus, scope.timestamp, scope.timeDiff);
         scope.healthClass = "health_" + status;
       };
 

--- a/console-frontend/js/filters.js
+++ b/console-frontend/js/filters.js
@@ -346,6 +346,34 @@ metricFilters.filter('simplifyTime', function() {
   };
 });
 
+metricFilters.filter('millSecondsToTimeString', function() {
+     return function(millseconds) {
+      var oneSecond = 1000;
+      var oneMinute = oneSecond * 60;
+      var oneHour = oneMinute * 60;
+      var oneDay = oneHour * 24;
+      var seconds = Math.floor((millseconds % oneMinute) / oneSecond);
+      var minutes = Math.floor((millseconds % oneHour) / oneMinute);
+      var hours = Math.floor((millseconds % oneDay) / oneHour);
+      var days = Math.floor(millseconds / oneDay);
+      var timeString = '';
+      if (days !== 0) {
+          timeString += (days !== 1) ? (days + ' days ') : (days + ' day ');
+      }
+      if (hours !== 0) {
+          timeString += (hours !== 1) ? (hours + ' hours ') : (hours + ' hour ');
+      }
+      if (minutes !== 0) {
+          timeString += (minutes !== 1) ? (minutes + ' minutes ') : (minutes + ' minute ');
+      }
+      if (seconds !== 0 && minutes === 0 && hours === 0 && days === 0) {
+         timeString = "just now";
+      }
+
+      return timeString;
+     };
+});
+
 metricFilters.filter('range', function() {
   return function(input, total) {
     total = parseInt(total, Constants.RADIX_DECIMAL);

--- a/console-frontend/js/services/timer.js
+++ b/console-frontend/js/services/timer.js
@@ -1,0 +1,43 @@
+/*-------------------------------------------------------------------------------
+* Name:        Timer.js
+* Purpose:     Service for timer.
+*
+* Author:      PNDA TEAM
+* Created:     2018/05/28
+* History:     2018/05/28 - Initial commit
+* Changes:     Added timer service
+*-------------------------------------------------------------------------------*/
+
+angular.module('appServices').factory('customTimer', ['$interval', function ($interval) {
+     var timerId;
+     var counter = 0;
+     var defaultInterval = 1000;
+     var callbacks = {};
+     var timer = {
+       start: function (timeInterval) {
+           if (timerId) return;
+           timerId = $interval( function() {
+              for( var callbackId in callbacks) {
+                callbacks[callbackId]();
+              }
+           }, timeInterval || defaultInterval );
+       },
+       on: function(callbackFun, context) {
+           if ( typeof callbackFun === "function" ) {
+              callbacks[counter++] = callbackFun;
+              timer.start();
+           }
+         },
+         off: function(callbackId) {
+             delete callbacks[callbackId];
+             if ( Object.keys(callbacks).length === 0 ) {
+                timer.destroy();
+             }
+        },
+       destroy : function(){
+         $interval.cancel(timerId);
+         timerId = undefined;
+       }
+     };
+     return timer;
+}]);

--- a/console-frontend/less/PNDA.less
+++ b/console-frontend/less/PNDA.less
@@ -625,3 +625,12 @@ div#applicationOverviewModal{
 .glyphicon-warning-sign{
    color: orange;
 }
+
+.custom-timer{
+    display: block;
+    font-size: 10px;
+    color: #444;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}

--- a/console-frontend/partials/components/pnda-basic-component.html
+++ b/console-frontend/partials/components/pnda-basic-component.html
@@ -1,6 +1,6 @@
 <div class="health {{class}}" ng-class="healthClass">
   <div class="componentName" ng-bind-html="metricName"></div>
-  <timer ng-attr-start-time="timestamp">Last update: {{millis | simplifyTime: days:hours:minutes:seconds}}</timer>
+  <span class="custom-timer">Last update: {{ timeDiff | millSecondsToTimeString}}  </span>
   <div class="info">
     <span ng-click="showDetails()" class="glyphicon glyphicon-exclamation-sign" aria-hidden="true" data-ng-show="!isUnavailable"></span>
     <span ng-click="showHelp()" class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>

--- a/console-frontend/partials/components/pnda-deployment-manager.html
+++ b/console-frontend/partials/components/pnda-deployment-manager.html
@@ -2,7 +2,7 @@
   <!-- title and health status -->
   <div class="health {{healthClass}}">
     <div class="componentName">Deployment Manager
-      <timer ng-attr-start-time="timestamp">Last update: {{millis | simplifyTime: days:hours:minutes:seconds}}</timer>
+      <span class="custom-timer">Last update: {{ timeDiff | millSecondsToTimeString}}  </span>
       <div class="info">
         <span ng-click="showDetails()" class="glyphicon glyphicon-exclamation-sign" aria-hidden="true" data-ng-show="!isUnavailable"></span>
         <span ng-click="showHelp()" class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>

--- a/console-frontend/partials/components/pnda-hdfs.html
+++ b/console-frontend/partials/components/pnda-hdfs.html
@@ -2,7 +2,7 @@
   <!-- title and health status -->
   <div class="health {{healthClass}}">
     {{metricName}}
-    <timer ng-attr-start-time="timestamp">Last update: {{millis | simplifyTime: days:hours:minutes:seconds}}</timer>
+   <span class="custom-timer">Last update: {{ timeDiff | millSecondsToTimeString}}  </span>
     <div class="info">
       <span ng-class="{'disabled': !showInfoIcon}" ng-click="showDetails(); $event.stopPropagation()" class="glyphicon glyphicon-exclamation-sign" aria-hidden="true" data-ng-show="!isUnavailable"></span>
       <span ng-click="showHelp()" class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>

--- a/console-frontend/partials/components/pnda-kafka.html
+++ b/console-frontend/partials/components/pnda-kafka.html
@@ -2,7 +2,7 @@
   <!-- title and health status -->
   <div class="health {{healthClass}}" ng-click="showDetails()">
     {{metricName}}
-    <timer ng-attr-start-time="timestamp">Last update: {{millis | simplifyTime: days:hours:minutes:seconds}}</timer>
+    <span class="custom-timer">Last update: {{ timeDiff | millSecondsToTimeString}}  </span>
     <div class="info">
       <span ng-click="showComponentInfo(); $event.stopPropagation()" class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
       <span ng-click="showHelp()" class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>

--- a/console-frontend/partials/components/pnda-yarn.html
+++ b/console-frontend/partials/components/pnda-yarn.html
@@ -2,7 +2,7 @@
   <!-- title and health status -->
   <div class="health {{healthClass}}">
     {{metricName}}
-    <timer ng-attr-start-time="timestamp">Last update: {{millis | simplifyTime: days:hours:minutes:seconds}}</timer>
+    <span class="custom-timer">Last update: {{ timeDiff | millSecondsToTimeString}}  </span>
     <div class="info">
       <span ng-click="showDetails()" class="glyphicon glyphicon-exclamation-sign" aria-hidden="true" data-ng-show="!isUnavailable"></span>
       <span ng-click="showHelp()" class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>


### PR DESCRIPTION
# Problem Statement : 
- PNDA-4133: If time on client browser is > 3 minutes out from the system then all components appear as "**no health status available**"

# Analysis :
- Since frontend is comparing PNDA time with user's system clock, hence it may give wrong results when user's system clock in another timezone.

# Change :
- Add a timer service which ticks until frontend gets metrics from backend.
- As soon as frontend gets the metrics, timer is reset.
- Display the elapsed time on homepage