### PR TITLE
PNDA-4761: Display correct metric age

### DIFF
--- a/console-frontend/js/components/pndaBasicComponent.js
+++ b/console-frontend/js/components/pndaBasicComponent.js
@@ -46,7 +46,6 @@ angular.module('appComponents').directive('pndaBasicComponent', ['$filter', 'Hel
         scope.metricObj = {};
         scope.fullMetrics = {};
         scope.severity = '';
-        scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
         scope.showDetails = function() {
           if (scope.severity) {
             scope.showOverview({ metricObj: scope.metricObj, metrics: scope.fullMetrics });
@@ -84,13 +83,8 @@ angular.module('appComponents').directive('pndaBasicComponent', ['$filter', 'Hel
               scope.metricName = scope.forceWrapDisplayName === "true" ?
                 scope.metricNameForModalView.replace(/ /g, '<br />') : scope.metricNameForModalView;
               scope.timestamp = healthMetric.info.timestamp;
-              scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-              if(scope.metricInfo && scope.metricInfo[healthMetric.name]){
-                scope.timeDiff = scope.metricInfo[healthMetric.name].timeDiff;
-              }
-              if(!scope.isUnavailable && scope.timeDiff === undefined){
-                  scope.timeDiff = 0;
-               }
+              scope.serverTime = $window.localStorage.getItem('serverTime');
+              scope.timeDiff = scope.serverTime - scope.timestamp;
               scope.severity = healthMetric.info.value;
               scope.metricObj = healthMetric;
               scope.class = $filter('metricNameClass')(healthMetric.name);
@@ -105,14 +99,8 @@ angular.module('appComponents').directive('pndaBasicComponent', ['$filter', 'Hel
         };
        
         var healthStatusCallbackFn = function() {
-          scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-          if(scope.metricInfo && scope.metricObj && scope.metricInfo[scope.metricObj.name]){
-            scope.timeDiff = scope.metricInfo[scope.metricObj.name].timeDiff;
-          }
-          //Initially
-          if(!scope.isUnavailable && scope.timeDiff === undefined){
-            scope.timeDiff = 0;
-          }
+          scope.serverTime = $window.localStorage.getItem('serverTime');
+          scope.timeDiff = scope.serverTime - scope.timestamp;
           scope.healthClass = " health_" + healthStatus(scope.latestHealthStatus, scope.timestamp, scope.timeDiff);
         };
 

--- a/console-frontend/js/components/pndaDeploymentManager.js
+++ b/console-frontend/js/components/pndaDeploymentManager.js
@@ -46,7 +46,6 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
         scope.orderProp = "name";
         scope.severity = '';
         scope.userName = $cookies.get('user');
-        scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
         scope.showDetails = function() {
           if (scope.severity) {
             scope.showOverview({ metricObj: scope.metricObj, metrics: scope.fullMetrics });
@@ -225,12 +224,8 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
               scope.severity = healthMetric.info.value;
               scope.metricObj = healthMetric;
               scope.isUnavailable = (healthMetric.info.value === "UNAVAILABLE");
-              if(scope.metricInfo && scope.metricInfo[healthMetric.name]){
-                  scope.timeDiff = scope.metricInfo[healthMetric.name].timeDiff;
-              }
-              if(!scope.isUnavailable && scope.timeDiff === undefined){
-                  scope.timeDiff = 0;
-              }
+              scope.serverTime = $window.localStorage.getItem('serverTime');
+              scope.timeDiff = scope.serverTime - scope.timestamp;
               scope.healthClass = "health_" + healthStatus(healthMetric.info.value, scope.timestamp, scope.timeDiff);
               scope.healthClass += (enableModalView(scope.severity) ? " clickable" : " ");
               scope.latestHealthStatus = healthMetric.info.value;
@@ -241,14 +236,8 @@ angular.module('appComponents').directive('pndaDeploymentManager', ['$filter', '
         };
         
         var healthStatusCallbackFn = function(now) {
-          scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-          if(scope.metricInfo && scope.metricObj && scope.metricInfo[scope.metricObj.name]){
-             scope.timeDiff = scope.metricInfo[scope.metricObj.name].timeDiff;
-          }
-          //Initially
-          if(!scope.isUnavailable && scope.timeDiff === undefined){
-             scope.timeDiff = 0;
-          }
+          scope.serverTime = $window.localStorage.getItem('serverTime');
+          scope.timeDiff = scope.serverTime - scope.timestamp;
           scope.healthClass = " health_" + healthStatus(scope.latestHealthStatus, scope.timestamp, scope.timeDiff);
         };
 

--- a/console-frontend/js/components/pndaHdfs.js
+++ b/console-frontend/js/components/pndaHdfs.js
@@ -45,7 +45,6 @@ angular.module('appComponents').directive('pndaHdfs', ['$filter', 'HelpService',
       scope.metrics = { live_datanodes: 0, total_files:0, non_dfs_used:0,
         dfs_used:0, total_size: 0, total_used: 0, jvm_heap_used:0, dead_datanodes:0 };
       scope.metricObj = {};
-      scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
 
       // the callback function expects an array of matching metrics
       scope.showDetails = function() {
@@ -91,13 +90,8 @@ angular.module('appComponents').directive('pndaHdfs', ['$filter', 'HelpService',
               scope.severity = metric.info.value;
               scope.timestamp = metric.info.timestamp;
               scope.isUnavailable = (metric.info.value === "UNAVAILABLE");
-              scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-              if(scope.metricInfo && scope.metricInfo[metric.name]){
-                scope.timeDiff = scope.metricInfo[metric.name].timeDiff;
-              }
-              if(!scope.isUnavailable && scope.timeDiff === undefined){
-                  scope.timeDiff = 0;
-              }
+              scope.serverTime = $window.localStorage.getItem('serverTime');
+              scope.timeDiff = scope.serverTime - scope.timestamp;
               var status = healthStatus(metric.info.value, scope.timestamp, scope.timeDiff);
 
 //              scope.healthClass += (enableModalView(scope.severity) ? " clickable" : " ");
@@ -155,14 +149,8 @@ angular.module('appComponents').directive('pndaHdfs', ['$filter', 'HelpService',
       };
 
       var healthStatusCallbackFn = function() {
-        scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-        if(scope.metricInfo && scope.metricObj && scope.metricInfo[scope.metricObj.name]){
-           scope.timeDiff = scope.metricInfo[scope.metricObj.name].timeDiff;
-        }
-        //Initially
-        if(!scope.isUnavailable && scope.timeDiff === undefined){
-            scope.timeDiff = 0;
-        }
+        scope.serverTime = $window.localStorage.getItem('serverTime');
+        scope.timeDiff = scope.serverTime - scope.timestamp;
         var status = healthStatus(scope.latestHealthStatus, scope.timestamp, scope.timeDiff);
         scope.healthClass = " health_" + status;
         scope.showInfoIcon = status === 'WARN' || status === 'ERROR';

--- a/console-frontend/js/components/pndaKafka.js
+++ b/console-frontend/js/components/pndaKafka.js
@@ -52,7 +52,6 @@ angular.module('appComponents').directive('pndaKafka',
       scope.severity = '';
       scope.chosenRate = 'MeanRate';
       scope.selectedPageCount = "5";
-      scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
       scope.rates = [
         { value:"FifteenMinuteRate", label:"15 minutes rate" },
         { value:"FiveMinuteRate", label:"5 minutes rate" },
@@ -147,13 +146,8 @@ angular.module('appComponents').directive('pndaKafka',
               scope.class = $filter('metricNameClass')(metric.name);
               scope.timestamp = metric.info.timestamp;
               scope.severity = metric.info.value;
-              scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-              if(scope.metricInfo && scope.metricInfo[metric.name]){
-                scope.timeDiff = scope.metricInfo[metric.name].timeDiff;
-              }
-              if(metric.info.value !== "UNAVAILABLE" && scope.timeDiff === undefined){
-                  scope.timeDiff = 0;
-              }
+              scope.serverTime = $window.localStorage.getItem('serverTime');
+              scope.timeDiff = scope.serverTime - scope.timestamp;
               scope.metricObj = metric;
               scope.isUnavailable = (metric.info.value === "UNAVAILABLE");
               scope.healthClass = "health_" + healthStatus(metric.info.value, scope.timestamp, scope.timeDiff);
@@ -248,14 +242,8 @@ angular.module('appComponents').directive('pndaKafka',
       };
 
       var healthStatusCallbackFn = function() {
-          scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-          if(scope.metricInfo && scope.metricObj && scope.metricInfo[scope.metricObj.name]){
-            scope.timeDiff = scope.metricInfo[scope.metricObj.name].timeDiff;
-          }
-          //Initially
-          if(!scope.isUnavailable && scope.timeDiff === undefined){
-            scope.timeDiff = 0;
-          }
+        scope.serverTime = $window.localStorage.getItem('serverTime');
+        scope.timeDiff = scope.serverTime - scope.timestamp;
         scope.healthClass = " health_" + healthStatus(scope.latestHealthStatus, scope.timestamp, scope.timeDiff);
       };
 

--- a/console-frontend/js/components/pndaYarn.js
+++ b/console-frontend/js/components/pndaYarn.js
@@ -43,7 +43,6 @@ angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService',
       scope.metricObj = {};
       scope.fullMetrics = {};
       scope.severity = '';
-      scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
 
       // total = allocated + available
       scope.memory = { total: 0, available: 0, allocated: 0, allocatedPercentage: 0, allocatedPercentageStyle: '' };
@@ -81,13 +80,8 @@ angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService',
               scope.metricObj = metric;
               scope.timestamp = metric.info.timestamp;
               scope.isUnavailable = (metric.info.value === "UNAVAILABLE");
-              scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-              if(scope.metricInfo && scope.metricInfo[metric.name]){
-                scope.timeDiff = scope.metricInfo[metric.name].timeDiff;
-              }
-              if(!scope.isUnavailable && scope.timeDiff === undefined){
-                  scope.timeDiff = 0;
-              }
+              scope.serverTime = $window.localStorage.getItem('serverTime');
+              scope.timeDiff = scope.serverTime - scope.timestamp;
               var status = healthStatus(metric.info.value, scope.timestamp, scope.timeDiff);
               scope.healthClass = "health_" + status;
 //              scope.healthClass += (enableModalView(scope.severity) ? " clickable" : " ");
@@ -121,14 +115,8 @@ angular.module('appComponents').directive('pndaYarn', ['$filter', 'HelpService',
       };
       
       var healthStatusCallbackFn = function() {
-        scope.metricInfo = JSON.parse($window.sessionStorage.getItem('metricTimeElapsedInfo')) || {};
-        if(scope.metricInfo && scope.metricObj && scope.metricInfo[scope.metricObj.name]){
-           scope.timeDiff = scope.metricInfo[scope.metricObj.name].timeDiff;
-        }
-        //Initially
-        if(!scope.isUnavailable && scope.timeDiff === undefined){
-           scope.timeDiff = 0;
-        }
+        scope.serverTime = $window.localStorage.getItem('serverTime');
+        scope.timeDiff = scope.serverTime - scope.timestamp;
         var status = healthStatus(scope.latestHealthStatus, scope.timestamp, scope.timeDiff);
         scope.healthClass = "health_" + status;
       };

--- a/console-frontend/js/controllers/ApplicationCtrl.js
+++ b/console-frontend/js/controllers/ApplicationCtrl.js
@@ -540,9 +540,11 @@ angular.module('appControllers').controller('ApplicationCtrl', ['$scope', '$filt
     socket.on('platform-console-frontend-application-update', socketApplicationsUpdate);
 
     $scope.appMetrics = [];
+    $scope.allMetrics = [];
 
     $scope.allMetrics = MetricService.query(function(response) {
-      angular.forEach(response, function(metric) {
+      $scope.allMetrics= response.metrics;
+      angular.forEach(response.metrics, function(metric) {
         // turn the 'value' promise into its value when it's available
         metric.info.then(function(response) {
           metric.info = response[0];

--- a/console-frontend/js/controllers/LoginCtrl.js
+++ b/console-frontend/js/controllers/LoginCtrl.js
@@ -67,7 +67,6 @@ angular.module('login').controller('LoginCtrl', ['$scope', '$http', '$location',
           //Getting session_max_age and time duration for warning message from backend in milliseconds
           var timeoutForLogout = response.data.session_max_age / 1000;
           var sessionExpiryWarningDuration = response.data.session_expiry_warning_duration / 1000;
-          $window.sessionStorage.setItem("metricTimeElapsedInfo",JSON.stringify({}));
           
           // add to cookies
           var expireDate = new Date();
@@ -153,11 +152,11 @@ angular.module('logout')
 
     // remove cookie data and logout user
     $rootScope.globals = {};
-    $window.sessionStorage.removeItem("metricTimeElapsedInfo");
     $cookies.remove('globals');
     $cookies.remove('userLoggedIn');
     $cookies.remove('user');
     $cookies.remove('userRole');
+    $window.localStorage.clear();
     $http({
     url: logoutPath,
     method: 'GET'

--- a/console-frontend/js/filters.js
+++ b/console-frontend/js/filters.js
@@ -357,6 +357,10 @@ metricFilters.filter('millSecondsToTimeString', function() {
       var hours = Math.floor((millseconds % oneDay) / oneHour);
       var days = Math.floor(millseconds / oneDay);
       var timeString = '';
+      if(millseconds < 0){
+         timeString = "just now";
+         return timeString;
+      }
       if (days !== 0) {
           timeString += (days !== 1) ? (days + ' days ') : (days + ' day ');
       }
@@ -366,7 +370,7 @@ metricFilters.filter('millSecondsToTimeString', function() {
       if (minutes !== 0) {
           timeString += (minutes !== 1) ? (minutes + ' minutes ') : (minutes + ' minute ');
       }
-      if (seconds !== 0 && minutes === 0 && hours === 0 && days === 0) {
+      if (seconds < 60 && minutes === 0 && hours === 0 && days === 0) {
          timeString = "just now";
       }
 

--- a/console-frontend/js/services/MetricService.js
+++ b/console-frontend/js/services/MetricService.js
@@ -28,14 +28,13 @@ angular.module('appServices').factory('MetricService', ['$resource', 'ConfigServ
   '$cookies', '$window', function($resource, ConfigService, $http, $q, $filter, $cookies, $window) {
     var dataManager = ConfigService.backend["data-manager"];
     var MetricService = $resource('/api/dm/metrics/:metricId?values=y', {}, {
-      query: { method:'GET', params:{ metricId:'' }, isArray:true, transformResponse: function(data) {
+      query: { method:'GET', params:{ metricId:'' }, transformResponse: function(data) {
         var json = JSON.parse(data);
-
         // if we received an array, it's the list of metrics
         if (json.metrics !== undefined && angular.isArray(json.metrics)) {
           // for each metric, get its latest value asynchronously using the /metrics/metricId API
           var metrics = [];
-
+          var response = {};
           angular.forEach(json.metrics, function (metric) {
             var deferred = $q.defer();
             deferred.resolve(metric.info);
@@ -56,7 +55,9 @@ angular.module('appServices').factory('MetricService', ['$resource', 'ConfigServ
               }
             }
           });
-          return metrics;
+          response.metrics = metrics;
+          response.serverTime = json.servertime;
+          return response;
         } else {
           console.log("not an array", json);
           if (json === "not authenticated") {

--- a/console-frontend/partials/curated-view.html
+++ b/console-frontend/partials/curated-view.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" type="text/css" id="theme" ng-href="{{theme}}">
-<div id="curatedView">
+<div id="curatedView" ng-if="metricLoaded">
   <div class="row first-row">
     <div id="platform" class="col-md-9 no-padding-right">
       <div class="panel panel-default">


### PR DESCRIPTION
# Problem Statement:
- PNDA 4761: On new window for existing session, or new session, metrics reported as 'just now' even if they're very old

# Change:
- Get the "server time" from server along with metrics response. 
- Run a timer to keep track of elapsed time
- Display a metric in gray if no updates has been received for 3 mins
