### PR TITLE
PNDA-4756:Show App metric in app page consistently

### DIFF
--- a/console-frontend/js/controllers/ApplicationCtrl.js
+++ b/console-frontend/js/controllers/ApplicationCtrl.js
@@ -34,6 +34,7 @@ angular.module('appControllers').controller('ApplicationCtrl', ['$scope', '$filt
     var defaultTimeout = 500;
     var yarnUrl;
     var userName = $cookies.get('user');
+    $scope.areMetricLoaded = false;
     
     function displayConfirmation(message, actionIfConfirmed) {
       var modalOptions = {
@@ -337,11 +338,12 @@ angular.module('appControllers').controller('ApplicationCtrl', ['$scope', '$filt
         $scope.getApplicationSummary(app.name);
         $scope.showApplicationDetail = true;
         $scope.metricFilter = 'application\\.kpi\\.' + app.name + '\\.';
+        if($scope.areMetricLoaded)
         $scope.appMetrics = $filter('getByNameForDisplay')($scope.allMetrics, $scope.metricFilter);
       }
     };
-	
-	$scope.getApplicationSummary = function(appName){
+
+    $scope.getApplicationSummary = function(appName){
        DeploymentManagerService.getApplicationSummary(appName).then(function(data) {
          $scope.appSummaryJson = data;
        });
@@ -544,6 +546,8 @@ angular.module('appControllers').controller('ApplicationCtrl', ['$scope', '$filt
 
     $scope.allMetrics = MetricService.query(function(response) {
       $scope.allMetrics= response.metrics;
+      $scope.appMetrics = $filter('getByNameForDisplay')($scope.allMetrics, $scope.metricFilter);
+      $scope.areMetricLoaded = true;
       angular.forEach(response.metrics, function(metric) {
         // turn the 'value' promise into its value when it's available
         metric.info.then(function(response) {

--- a/console-frontend/partials/applications.html
+++ b/console-frontend/partials/applications.html
@@ -99,9 +99,10 @@
                       <pnda-tree-view json="{{ appDetailJson }}" editable="false" on-confirm-overrides="getOverrides(overrides)"></pnda-tree-view>
                     </div>
                     <div id="tab-metrics" class="tab-pane fade">
+                      <div ng-if="!areMetricLoaded" class="no-metrics-available">Loading...</div>
                       <div ng-if="appMetrics.length === 0" class="no-metrics-available">No metrics available.</div>
                       <div ng-if="appMetrics.length > 0">
-                        <table id="app-metrics" class="table table-hover table-condensed">
+                        <table id="app-metrics" class="table table-hover table-condensed" ng-if="areMetricLoaded">
                           <thead>
                           <tr>
                             <th>Metric</th>


### PR DESCRIPTION
# Problem Statement:
- PNDA-4756: App metric not shown in app page

# Change:
- Update app metric once get-metric rest call is completed.
- If it is taking too long to complete the rest call then tab-metrics will show "Loading.." text until metric call is completed.